### PR TITLE
Add the Log deprecated notices extender plugin.

### DIFF
--- a/vvv-init.sh
+++ b/vvv-init.sh
@@ -67,6 +67,7 @@ PHP
 	wp plugin install debug-bar-extender  --activate --allow-root
 	wp plugin install rewrite-rules-inspector  --activate --allow-root
 	wp plugin install log-deprecated-notices  --activate --allow-root
+	wp plugin install log-deprecated-notices-extender  --activate --allow-root
 	wp plugin install log-viewer  --activate --allow-root
 	wp plugin install monster-widget  --activate --allow-root
 	wp plugin install user-switching  --activate --allow-root


### PR DESCRIPTION
This will show a button in the admin bar if deprecated notices have been detected. Otherwise, they easily go unnoticed.

![screenshot](https://snag.gy/mBlhEf.jpg)