### PR TITLE
Fix persistent errors in plugins

### DIFF
--- a/vvv-init.sh
+++ b/vvv-init.sh
@@ -51,7 +51,13 @@ PHP
 	# **
 
 	printf 'Installing plugins...\n'
-	wp plugin install wordpress-importer --activate --allow-root
+	wp plugin install wordpress-importer --allow-root
+	# Fix PHP7 compatibility variable variables in the WP Importer plugin.
+	echo "Removing errors from the WP Importer plugin."
+	if [[ -f /srv/www/wordpress-themereview-vvv/htdocs/wp-content/plugins/wordpress-importer/wordpress-importer.php ]]; then
+		sed -i -e "s/\$\$meta\['key'] = \$meta\['value'];/\${\$meta['key']} = \$meta['value'];/g" "/srv/www/wordpress-themereview-vvv/htdocs/wp-content/plugins/wordpress-importer/wordpress-importer.php"
+	fi
+	wp plugin activate wordpress-importer --allow-root
 	wp plugin install developer --activate --allow-root
 	wp plugin install theme-check --activate --allow-root
 	wp plugin install theme-mentor --activate --allow-root
@@ -66,7 +72,14 @@ PHP
 	wp plugin install debug-bar-cron  --activate --allow-root
 	wp plugin install debug-bar-extender  --activate --allow-root
 	wp plugin install rewrite-rules-inspector  --activate --allow-root
-	wp plugin install log-deprecated-notices  --activate --allow-root
+
+	wp plugin install log-deprecated-notices --allow-root
+	# Fix PHP4 constructor in the Log Deprecated Notices plugin.
+	echo "Removing errors from the Log Deprecated Notices plugin."
+	if [[ -f /srv/www/wordpress-themereview-vvv/htdocs/wp-content/plugins/log-deprecated-notices/log-deprecated-notices.php ]]; then
+		sed -i -e 's/function Deprecated_Log() {/function __construct() {/g' "/srv/www/wordpress-themereview-vvv/htdocs/wp-content/plugins/log-deprecated-notices/log-deprecated-notices.php"
+	fi
+	wp plugin activate log-deprecated-notices --allow-root
 	wp plugin install log-viewer  --activate --allow-root
 	wp plugin install monster-widget  --activate --allow-root
 	wp plugin install user-switching  --activate --allow-root
@@ -120,4 +133,21 @@ else
 
 	cd ..
 
+fi
+
+
+# =============================================================================
+# Removing Errors
+# =============================================================================
+
+# Fix PHP7 compatibility variable variables in the WP Importer plugin.
+echo "Removing errors from the WP Importer plugin."
+if [[ -f /srv/www/wordpress-themereview-vvv/htdocs/wp-content/plugins/wordpress-importer/wordpress-importer.php ]]; then
+	sed -i -e 's/\$\$meta\['key'\] = \$meta\['value'\];/\${\$meta['key']} = \$meta['value'];/g' "/srv/www/wordpress-themereview-vvv/htdocs/wp-content/plugins/wordpress-importer/wordpress-importer.php"
+fi
+
+# Fix PHP4 constructor in the Log Deprecated Notices plugin.
+echo "Removing errors from the Log Deprecated Notices plugin."
+if [[ -f /srv/www/wordpress-themereview-vvv/htdocs/wp-content/plugins/log-deprecated-notices/log-deprecated-notices.php ]]; then
+	sed -i -e 's/function Deprecated_Log() {/function __construct() {/' "/srv/www/wordpress-themereview-vvv/htdocs/wp-content/plugins/log-deprecated-notices/log-deprecated-notices.php"
 fi


### PR DESCRIPTION
The new version of VVV will be running PHP 7.

The Log Deprecated Notices plugin doesn't really have an alternative, but is not actively maintained nor has it got a GH shadow with more up to date code.
This plugin has a PHP7 compatibility issue which this adjustment fixes.

The WordPress Importer is needed to import the theme test data, but also has PHP7 compatibility issues. HumanMade is working on a refactor, but replacing the current plugin with the refactored one broke the importing of the unit test data, so for now, fixing the PHP 7 issue in the WordPress Importer plugin seemed the simpler solution.
Ref: https://github.com/humanmade/WordPress-Importer

The fixes are made by editing the actual plugin files. This is done right after install, but also at the end of the script so as to fix already installed versions of the plugins.

This gets rid of the following errors which will show in the VVV provision logs and/or PHP error logs:

```
# Log Deprecated Notices
Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; Deprecated_Log has a deprecated constructor in /srv/www/wordpress-themereview-vvv/htdocs/wp-content/plugins/log-deprecated-notices/log-deprecated-notices.php on line 25

# WordPress Importer
Notice: Array to string conversion in /srv/www/wordpress-themereview-vvv/htdocs/wp-content/plugins/wordpress-importer/wordpress-importer.php on line 884
Notice: Undefined variable: _menu_item_type in /srv/www/wordpress-themereview-vvv/htdocs/wp-content/plugins/wordpress-importer/wordpress-importer.php on line 886
Notice: Undefined variable: _menu_item_type in /srv/www/wordpress-themereview-vvv/htdocs/wp-content/plugins/wordpress-importer/wordpress-importer.php on line 888
Notice: Undefined variable: _menu_item_type in /srv/www/wordpress-themereview-vvv/htdocs/wp-content/plugins/wordpress-importer/wordpress-importer.php on line 890
```
